### PR TITLE
Update structure to include common definitions and page-specific definitions

### DIFF
--- a/gui_agent_loop_core/rule_config/common_definitions/common_definitions.yaml
+++ b/gui_agent_loop_core/rule_config/common_definitions/common_definitions.yaml
@@ -1,0 +1,14 @@
+common_elements:
+  - name: commonLabel
+    type: label
+    description: "共通ラベル"
+    required: true
+    attributes:
+      for: "commonInput"
+
+  - name: commonRadio
+    type: radio
+    description: "共通ラジオボタン"
+    required: false
+    attributes:
+      name: "commonOptions"

--- a/gui_agent_loop_core/rule_config/page_definitions/page1/form1.yaml
+++ b/gui_agent_loop_core/rule_config/page_definitions/page1/form1.yaml
@@ -1,0 +1,37 @@
+root_element:
+  name: "FormA"
+  type: "form"
+  description: "このフォームはラベルとラジオボタンの関係を定義します。"
+  attributes:
+    action: "/submit"
+    method: "post"
+  elements:
+    - name: AAA
+      type: label
+      description: "このラベルは必須です。"
+      required: true
+      attributes:
+        for: "input1"
+      check:
+        condition: "every"
+        target: "label"
+
+    - name: BBB
+      type: radio
+      description: "このラジオボタンはオプションです。"
+      required: false
+      attributes:
+        id: "input1"
+        name: "options"
+      prohibited: false
+      check:
+        condition: "first_only"
+        target: "radio"
+
+    - name: commonLabel
+      type: label
+      description: "共通ラベルを使用しています。"
+      required: true
+      attributes:
+        for: "commonInput"
+      uses_common: true  # 共通要素を使用することを明示

--- a/gui_agent_loop_core/rule_config/page_definitions/page1/root_element_relations.yaml
+++ b/gui_agent_loop_core/rule_config/page_definitions/page1/root_element_relations.yaml
@@ -1,0 +1,7 @@
+root_element_relations:
+  - source: "FormA"
+    target: "FormB"
+    condition: "exists"  # FormAが存在する場合にFormBをチェック
+  - source: "FormC"
+    target: "commonLabel"
+    condition: "uses_common"  # FormCが共通ラベルを使用する場合

--- a/gui_agent_loop_core/rule_config/page_definitions/page2/form1.yaml
+++ b/gui_agent_loop_core/rule_config/page_definitions/page2/form1.yaml
@@ -1,0 +1,37 @@
+root_element:
+  name: "FormB"
+  type: "form"
+  description: "このフォームはラベルとラジオボタンの関係を定義します。"
+  attributes:
+    action: "/submit"
+    method: "post"
+  elements:
+    - name: CCC
+      type: label
+      description: "このラベルは必須です。"
+      required: true
+      attributes:
+        for: "input2"
+      check:
+        condition: "every"
+        target: "label"
+
+    - name: DDD
+      type: radio
+      description: "このラジオボタンはオプションです。"
+      required: false
+      attributes:
+        id: "input2"
+        name: "options"
+      prohibited: false
+      check:
+        condition: "first_only"
+        target: "radio"
+
+    - name: commonRadio
+      type: radio
+      description: "共通ラジオボタンを使用しています。"
+      required: false
+      attributes:
+        name: "commonOptions"
+      uses_common: true  # 共通要素を使用することを明示

--- a/gui_agent_loop_core/rule_config/page_definitions/page2/root_element_relations.yaml
+++ b/gui_agent_loop_core/rule_config/page_definitions/page2/root_element_relations.yaml
@@ -1,0 +1,7 @@
+root_element_relations:
+  - source: "FormB"
+    target: "FormD"
+    condition: "exists"  # FormBが存在する場合にFormDをチェック
+  - source: "FormE"
+    target: "commonRadio"
+    condition: "uses_common"  # FormEが共通ラジオボタンを使用する場合


### PR DESCRIPTION
Add new YAML files to define common elements and page-specific configurations.

* **Common Definitions:**
  - Add `common_definitions.yaml` to define common elements such as `commonLabel` and `commonRadio` with attributes and descriptions.

* **Page 1 Definitions:**
  - Add `root_element_relations.yaml` to define root element relations for page1 with conditions like `exists` and `uses_common`.
  - Add `form1.yaml` to define root element for FormA, including elements such as labels and radio buttons with attributes and descriptions. Specify the use of common elements with `uses_common: true`.

* **Page 2 Definitions:**
  - Add `root_element_relations.yaml` to define root element relations for page2 with conditions like `exists` and `uses_common`.
  - Add `form1.yaml` to define root element for FormB, including elements such as labels and radio buttons with attributes and descriptions. Specify the use of common elements with `uses_common: true`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/GuiAgentLoopCore/pull/3?shareId=b1783f4e-8f86-447f-bde1-4320f3364ce4).